### PR TITLE
fix: filter new fam att

### DIFF
--- a/src/pages/department/newfamily/attendance/index.tsx
+++ b/src/pages/department/newfamily/attendance/index.tsx
@@ -180,7 +180,7 @@ const NewfamilyAttendancePage: NextPage = () => {
   useEffect(() => {
     if (newFamilyGroupAttendanceData)
       setNewfamilyGroupAttendanceData(newFamilyGroupAttendanceData);
-  }, []);
+  }, [newFamilyGroupAttendanceData]);
 
   return (
     <>


### PR DESCRIPTION
새가족 출석 페이지 들어갈 때 데이터 바로 안 뜨는 이슈랑 탭 누르면 새가족 순장 별로 출석 데이터 필터링 안 되는 이슈 해결